### PR TITLE
Minor doc fix: azure.json should be used for deployment to azure vnet.

### DIFF
--- a/adds-extend-domain/README.md
+++ b/adds-extend-domain/README.md
@@ -53,7 +53,7 @@ A deployment for this architecture is available on [GitHub][github]. Note that t
 3. Run the following command and wait for the deployment to finish.
 
     ```bash
-    azbb -s <subscription_id> -g <resource group> -l <location> -p onoprem.json --deploy
+    azbb -s <subscription_id> -g <resource group> -l <location> -p azure.json --deploy
     ```
 
    Deploy to the same resource group as the on-premises VNet.

--- a/adds-forest/README.md
+++ b/adds-forest/README.md
@@ -53,7 +53,7 @@ A deployment for this architecture is available on [GitHub][github]. Note that t
 3. Run the following command and wait for the deployment to finish.
 
     ```bash
-    azbb -s <subscription_id> -g <resource group> -l <location> -p onoprem.json --deploy
+    azbb -s <subscription_id> -g <resource group> -l <location> -p azure.json --deploy
     ```
 
    Deploy to the same resource group as the on-premises VNet.


### PR DESCRIPTION
The documentation erroneously mentions that `onoprem.json` (sic) should be used for azure vnet deployment. It should actually be `azure.json`.