### PR TITLE
Changes the way load balancer are linked to VMs and others

### DIFF
--- a/azure-ad/README.md
+++ b/azure-ad/README.md
@@ -14,7 +14,7 @@ A deployment for a reference architecture that implements these recommendations 
 
 1. Clone, fork, or download the zip file for the [identity reference architectures](https://github.com/mspnp/identity-reference-architectures) GitHub repository.
 
-2. Install [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest).
+2. Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest).
 
 3. Install the [Azure building blocks](https://github.com/mspnp/template-building-blocks/wiki/Install-Azure-Building-Blocks) npm package.
 

--- a/azure-ad/ntier-linux.json
+++ b/azure-ad/ntier-linux.json
@@ -34,89 +34,26 @@
             }
           ]
         },
-        {
-          "type": "LoadBalancer",
-          "settings": [
-            {
-              "name": "ra-aad-ntier-web-lb",
-              "virtualNetwork": {
-                "name": "ra-aad-ntier-vnet"
-              },
-              "frontendIPConfigurations": [
-                {
-                  "name": "ra-aad-ntier-web-lb-fe-config1",
-                  "loadBalancerType": "Public"
-                }
-              ],
-              "loadBalancingRules": [
-                {
-                  "name": "web-lbr1",
-                  "frontendPort": 80,
-                  "backendPort": 80,
-                  "protocol": "Tcp",
-                  "backendPoolName": "web-lb-bep1",
-                  "frontendIPConfigurationName": "ra-aad-ntier-web-lb-fe-config1",
-                  "enableFloatingIP": false,
-                  "probeName": "web-lbp1"
-                },
-                {
-                  "name": "web-lbr2",
-                  "frontendPort": 443,
-                  "backendPort": 443,
-                  "protocol": "Tcp",
-                  "backendPoolName": "web-lb-bep1",
-                  "frontendIPConfigurationName": "ra-aad-ntier-web-lb-fe-config1",
-                  "enableFloatingIP": false,
-                  "probeName": "web-lbp2"
-                }
-              ],
-              "probes": [
-                {
-                  "name": "web-lbp1",
-                  "port": 80,
-                  "protocol": "Http",
-                  "requestPath": "/"
-                },
-                {
-                  "name": "web-lbp2",
-                  "port": 443,
-                  "protocol": "Tcp",
-                  "requestPath": null
-                }
-              ],
-              "backendPools": [
-                {
-                  "name": "web-lb-bep1",
-                  "nicIndex": 0
-                }
-              ],
-              "inboundNatRules": []
-            }
-          ]
-        },
+        
         {
           "type": "VirtualMachine",
           "settings": {
-            "vmCount": 3,
-            "namePrefix": "ra-aad-ntier-web",
+            "vmCount": 1,
+            "namePrefix": "ra-aad-ntier-mgmt",
             "computerNamePrefix": "cn",
             "size": "Standard_DS1_v2",
             "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
+            "adminPassword": "<placeholder>",
             "osType": "linux",
             "virtualNetwork": {
               "name": "ra-aad-ntier-vnet"
             },
             "nics": [
               {
-                "subnetName": "web",
-                "privateIPAllocationMethod": "Dynamic",
-                "backendPoolNames": [
-                  {
-                    "name": "web-lb-bep1",
-                    "loadBalancerName": "ra-aad-ntier-web-lb"
-                  }
-                ]
+                "isPublic": true,
+                "publicIPAllocationMethod": "Static",
+                "subnetName": "mgmt",
+                "privateIPAllocationMethod": "Dynamic"
               }
             ],
             "imageReference": {
@@ -133,6 +70,106 @@
             }
           }
         },
+        {
+          "type": "VirtualMachine",
+          "settings": {
+            "vmCount": 3,
+            "namePrefix": "ra-aad-ntier-web",
+            "computerNamePrefix": "cn",
+            "size": "Standard_DS1_v2",
+            "adminUsername": "testuser",
+            "adminPassword": "<placeholder>",
+            "osType": "linux",
+            "virtualNetwork": {
+              "name": "ra-aad-ntier-vnet"
+            },
+            "nics": [
+              {
+                "subnetName": "web",
+                "privateIPAllocationMethod": "Dynamic"
+              }
+            ],
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "14.04.5-LTS",
+              "version": "latest"
+            },
+            "dataDisks": {
+              "count": 1,
+              "diskSizeGB": 127,
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          }
+        },
+        {
+          "type": "VirtualMachine",
+          "settings": {
+            "vmCount": 3,
+            "namePrefix": "ra-aad-ntier-biz",
+            "computerNamePrefix": "cn",
+            "size": "Standard_DS1_v2",
+            "adminUsername": "testuser",
+            "adminPassword": "<placeholder>",
+            "osType": "linux",
+            "virtualNetwork": {
+              "name": "ra-aad-ntier-vnet"
+            },
+            "nics": [
+              {
+                "subnetName": "biz",
+                "privateIPAllocationMethod": "Dynamic"
+              }
+            ],
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "14.04.5-LTS",
+              "version": "latest"
+            },
+            "dataDisks": {
+              "count": 1,
+              "diskSizeGB": 127,
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          }
+        },
+        {
+          "type": "VirtualMachine",
+          "settings": {
+            "vmCount": 3,
+            "namePrefix": "ra-aad-ntier-data",
+            "computerNamePrefix": "cn",
+            "size": "Standard_DS1_v2",
+            "adminUsername": "testuser",
+            "adminPassword": "<placeholder>",
+            "osType": "linux",
+            "virtualNetwork": {
+              "name": "ra-aad-ntier-vnet"
+            },
+            "nics": [
+              {
+                "subnetName": "data",
+                "privateIPAllocationMethod": "Dynamic"
+              }
+            ],
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "14.04.5-LTS",
+              "version": "latest"
+            },
+            "dataDisks": {
+              "count": 1,
+              "diskSizeGB": 127,
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          }
+        },
+
         {
           "type": "VirtualMachineExtension",
           "settings": [
@@ -162,9 +199,53 @@
             }
           ]
         },
+
         {
           "type": "LoadBalancer",
           "settings": [
+            {
+              "name": "ra-aad-ntier-web-lb",
+              "virtualNetwork": {
+                "name": "ra-aad-ntier-vnet"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "name": "ra-aad-ntier-web-lb-fe-config1",
+                  "loadBalancerType": "Public"
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "web-lbr1",
+                  "frontendPort": 80,
+                  "backendPort": 80,
+                  "protocol": "Tcp",
+                  "backendPoolName": "web-lb-bep1",
+                  "frontendIPConfigurationName": "ra-aad-ntier-web-lb-fe-config1",
+                  "enableFloatingIP": false,
+                  "probeName": "web-lbp1"
+                }
+              ],
+              "probes": [
+                {
+                  "name": "web-lbp1",
+                  "port": 80,
+                  "protocol": "Http",
+                  "requestPath": "/"
+                }
+              ],
+              "backendPools": [
+                {
+                  "name": "web-lb-bep1",
+                  "nics": [
+                    "ra-aad-ntier-web-vm1-nic1",
+                    "ra-aad-ntier-web-vm2-nic1",
+                    "ra-aad-ntier-web-vm3-nic1"
+                  ]
+                }
+              ],
+              "inboundNatRules": []
+            },
             {
               "name": "ra-aad-ntier-biz-lb",
               "virtualNetwork": {
@@ -203,55 +284,15 @@
               "backendPools": [
                 {
                   "name": "biz-lb-bep1",
-                  "nicIndex": 0
+                  "nics": [
+                    "ra-aad-ntier-biz-vm1-nic1",
+                    "ra-aad-ntier-biz-vm2-nic1",
+                    "ra-aad-ntier-biz-vm3-nic1"
+                  ]
                 }
               ],
               "inboundNatRules": []
-            }
-          ]
-        },
-        {
-          "type": "VirtualMachine",
-          "settings": {
-            "vmCount": 3,
-            "namePrefix": "ra-aad-ntier-biz",
-            "computerNamePrefix": "cn",
-            "size": "Standard_DS1_v2",
-            "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
-            "osType": "linux",
-            "virtualNetwork": {
-              "name": "ra-aad-ntier-vnet"
             },
-            "nics": [
-              {
-                "subnetName": "biz",
-                "privateIPAllocationMethod": "Dynamic",
-                "backendPoolNames": [
-                  {
-                    "name": "biz-lb-bep1",
-                    "loadBalancerName": "ra-aad-ntier-biz-lb"
-                  }
-                ]
-              }
-            ],
-            "imageReference": {
-              "publisher": "Canonical",
-              "offer": "UbuntuServer",
-              "sku": "14.04.5-LTS",
-              "version": "latest"
-            },
-            "dataDisks": {
-              "count": 1,
-              "diskSizeGB": 127,
-              "caching": "None",
-              "createOption": "Empty"
-            }
-          }
-        },
-        {
-          "type": "LoadBalancer",
-          "settings": [
             {
               "name": "ra-aad-ntier-data-lb",
               "virtualNetwork": {
@@ -290,90 +331,95 @@
               "backendPools": [
                 {
                   "name": "data-lb-bep1",
-                  "nicIndex": 0
+                  "nics": [
+                    "ra-aad-ntier-data-vm1-nic1",
+                    "ra-aad-ntier-data-vm2-nic1",
+                    "ra-aad-ntier-data-vm3-nic1"
+                  ]
                 }
               ],
               "inboundNatRules": []
             }
           ]
         },
-        {
-          "type": "VirtualMachine",
-          "settings": {
-            "vmCount": 3,
-            "namePrefix": "ra-aad-ntier-data",
-            "computerNamePrefix": "cn",
-            "size": "Standard_DS1_v2",
-            "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
-            "osType": "linux",
-            "virtualNetwork": {
-              "name": "ra-aad-ntier-vnet"
-            },
-            "nics": [
-              {
-                "subnetName": "data",
-                "privateIPAllocationMethod": "Dynamic",
-                "backendPoolNames": [
-                  {
-                    "name": "data-lb-bep1",
-                    "loadBalancerName": "ra-aad-ntier-data-lb"
-                  }
-                ]
-              }
-            ],
-            "imageReference": {
-              "publisher": "Canonical",
-              "offer": "UbuntuServer",
-              "sku": "14.04.5-LTS",
-              "version": "latest"
-            },
-            "dataDisks": {
-              "count": 1,
-              "diskSizeGB": 127,
-              "caching": "None",
-              "createOption": "Empty"
-            }
-          }
-        },
-        {
-          "type": "VirtualMachine",
-          "settings": {
-            "vmCount": 1,
-            "namePrefix": "ra-aad-ntier-mgmt",
-            "computerNamePrefix": "cn",
-            "size": "Standard_DS1_v2",
-            "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
-            "osType": "linux",
-            "virtualNetwork": {
-              "name": "ra-aad-ntier-vnet"
-            },
-            "nics": [
-              {
-                "isPublic": true,
-                "publicIPAllocationMethod": "Static",
-                "subnetName": "mgmt",
-                "privateIPAllocationMethod": "Dynamic"
-              }
-            ],
-            "imageReference": {
-              "publisher": "Canonical",
-              "offer": "UbuntuServer",
-              "sku": "14.04.5-LTS",
-              "version": "latest"
-            },
-            "dataDisks": {
-              "count": 1,
-              "diskSizeGB": 127,
-              "caching": "None",
-              "createOption": "Empty"
-            }
-          }
-        },
+
         {
           "type": "NetworkSecurityGroup",
           "settings": [
+            {
+              "name": "ra-aad-ntier-mgmt-nsg",
+              "virtualNetworks": [
+                {
+                  "name": "ra-aad-ntier-vnet",
+                  "subnets": [
+                    "mgmt"
+                  ]
+                }
+              ],
+              "securityRules": [
+                {
+                  "name": "default-allow-ssh",
+                  "direction": "Inbound",
+                  "priority": 100,
+                  "sourceAddressPrefix": "*",
+                  "destinationAddressPrefix": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 22,
+                  "access": "Allow",
+                  "protocol": "TCP"
+                }
+              ]
+            },
+
+            {
+              "name": "ra-aad-ntier-web-nsg",
+              "virtualNetworks": [
+                {
+                  "name": "ra-aad-ntier-vnet",
+                  "subnets": [
+                    "web"
+                  ]
+                }
+              ],
+              "securityRules": [
+                {
+                  "name": "allow-http-traffic-from-external",
+                  "description": "Allow http traffic originating externally.",
+                  "protocol": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 80,
+                  "sourceAddressPrefix": "*",
+                  "destinationAddressPrefix": "*",
+                  "access": "Allow",
+                  "priority": 100,
+                  "direction": "Inbound"
+                },
+                {
+                  "name": "allow-http-traffic-from-vnet",
+                  "description": "Allow http traffic originating from vnet.",
+                  "protocol": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 80,
+                  "sourceAddressPrefix": "10.0.0.0/16",
+                  "destinationAddressPrefix": "*",
+                  "access": "Allow",
+                  "priority": 200,
+                  "direction": "Inbound"
+                },
+                {
+                  "name": "allow-mgmt-ssh",
+                  "direction": "Inbound",
+                  "priority": 300,
+                  "sourceAddressPrefix": "10.0.0.128/25",
+                  "destinationAddressPrefix": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 22,
+                  "access": "Allow",
+                  "protocol": "TCP"
+                }
+              ]
+            },
+
             {
               "name": "ra-aad-ntier-biz-nsg",
               "virtualNetworks": [
@@ -400,28 +446,17 @@
                 {
                   "name": "allow-mgmt-ssh",
                   "direction": "Inbound",
-                  "priority": 110,
+                  "priority": 200,
                   "sourceAddressPrefix": "10.0.0.128/25",
                   "destinationAddressPrefix": "*",
                   "sourcePortRange": "*",
                   "destinationPortRange": 22,
                   "access": "Allow",
                   "protocol": "TCP"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 120,
-                  "direction": "Inbound"
                 }
               ]
             },
+
             {
               "name": "ra-aad-ntier-data-nsg",
               "virtualNetworks": [
@@ -448,7 +483,7 @@
                 {
                   "name": "allow-mgmt-ssh",
                   "direction": "Inbound",
-                  "priority": 110,
+                  "priority": 200,
                   "sourceAddressPrefix": "10.0.0.128/25",
                   "destinationAddressPrefix": "*",
                   "sourcePortRange": "*",
@@ -465,139 +500,7 @@
                   "sourceAddressPrefix": "*",
                   "destinationAddressPrefix": "*",
                   "access": "Allow",
-                  "priority": 120,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 130,
-                  "direction": "Inbound"
-                }
-              ]
-            },
-            {
-              "name": "ra-aad-ntier-web-nsg",
-              "virtualNetworks": [
-                {
-                  "name": "ra-aad-ntier-vnet",
-                  "subnets": [
-                    "web"
-                  ]
-                }
-              ],
-              "securityRules": [
-                {
-                  "name": "allow-http-traffic-from-external",
-                  "description": "Allow http traffic originating externally.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 80,
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 100,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-https-traffic-from-external",
-                  "description": "Allow https traffic originating externally.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 443,
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 110,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-http-traffic-from-vnet",
-                  "description": "Allow http traffic originating from vnet.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 80,
-                  "sourceAddressPrefix": "10.0.0.0/16",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 120,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-https-traffic-from-vnet",
-                  "description": "Allow https traffic originating from vnet.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 443,
-                  "sourceAddressPrefix": "10.0.0.0/16",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 130,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-mgmt-ssh",
-                  "direction": "Inbound",
-                  "priority": 140,
-                  "sourceAddressPrefix": "10.0.0.128/25",
-                  "destinationAddressPrefix": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 22,
-                  "access": "Allow",
-                  "protocol": "TCP"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 150,
-                  "direction": "Inbound"
-                }
-              ]
-            },
-            {
-              "name": "ra-aad-ntier-mgmt-nsg",
-              "virtualNetworks": [
-                {
-                  "name": "ra-aad-ntier-vnet",
-                  "subnets": [
-                    "mgmt"
-                  ]
-                }
-              ],
-              "securityRules": [
-                {
-                  "name": "default-allow-ssh",
-                  "direction": "Inbound",
-                  "priority": 100,
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 22,
-                  "access": "Allow",
-                  "protocol": "TCP"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 110,
+                  "priority": 300,
                   "direction": "Inbound"
                 }
               ]

--- a/azure-ad/ntier-windows.json
+++ b/azure-ad/ntier-windows.json
@@ -34,89 +34,26 @@
             }
           ]
         },
-        {
-          "type": "LoadBalancer",
-          "settings": [
-            {
-              "name": "ra-aad-ntier-web-lb",
-              "virtualNetwork": {
-                "name": "ra-aad-ntier-vnet"
-              },
-              "frontendIPConfigurations": [
-                {
-                  "name": "ra-aad-ntier-web-lb-fe-config1",
-                  "loadBalancerType": "Public"
-                }
-              ],
-              "loadBalancingRules": [
-                {
-                  "name": "web-lbr1",
-                  "frontendPort": 80,
-                  "backendPort": 80,
-                  "protocol": "Tcp",
-                  "backendPoolName": "web-lb-bep1",
-                  "frontendIPConfigurationName": "ra-aad-ntier-web-lb-fe-config1",
-                  "enableFloatingIP": false,
-                  "probeName": "web-lbp1"
-                },
-                {
-                  "name": "web-lbr2",
-                  "frontendPort": 443,
-                  "backendPort": 443,
-                  "protocol": "Tcp",
-                  "backendPoolName": "web-lb-bep1",
-                  "frontendIPConfigurationName": "ra-aad-ntier-web-lb-fe-config1",
-                  "enableFloatingIP": false,
-                  "probeName": "web-lbp2"
-                }
-              ],
-              "probes": [
-                {
-                  "name": "web-lbp1",
-                  "port": 80,
-                  "protocol": "Http",
-                  "requestPath": "/"
-                },
-                {
-                  "name": "web-lbp2",
-                  "port": 443,
-                  "protocol": "Tcp",
-                  "requestPath": null
-                }
-              ],
-              "backendPools": [
-                {
-                  "name": "web-lb-bep1",
-                  "nicIndex": 0
-                }
-              ],
-              "inboundNatRules": []
-            }
-          ]
-        },
+        
         {
           "type": "VirtualMachine",
           "settings": {
-            "vmCount": 3,
-            "namePrefix": "ra-aad-ntier-web",
+            "vmCount": 1,
+            "namePrefix": "ra-aad-ntier-mgmt",
             "computerNamePrefix": "cn",
             "size": "Standard_DS1_v2",
             "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
+            "adminPassword": "<placeholder>",
             "osType": "windows",
             "virtualNetwork": {
               "name": "ra-aad-ntier-vnet"
             },
             "nics": [
               {
-                "subnetName": "web",
-                "privateIPAllocationMethod": "Dynamic",
-                "backendPoolNames": [
-                  {
-                    "name": "web-lb-bep1",
-                    "loadBalancerName": "ra-aad-ntier-web-lb"
-                  }
-                ]
+                "isPublic": true,
+                "publicIPAllocationMethod": "Static",
+                "subnetName": "mgmt",
+                "privateIPAllocationMethod": "Dynamic"
               }
             ],
             "imageReference": {
@@ -133,6 +70,109 @@
             }
           }
         },
+
+        {
+          "type": "VirtualMachine",
+          "settings": {
+            "vmCount": 3,
+            "namePrefix": "ra-aad-ntier-web",
+            "computerNamePrefix": "cn",
+            "size": "Standard_DS1_v2",
+            "adminUsername": "testuser",
+            "adminPassword": "<placeholder>",
+            "osType": "windows",
+            "virtualNetwork": {
+              "name": "ra-aad-ntier-vnet"
+            },
+            "nics": [
+              {
+                "subnetName": "web",
+                "privateIPAllocationMethod": "Dynamic"
+              }
+            ],
+            "imageReference": {
+              "publisher": "MicrosoftWindowsServer",
+              "offer": "WindowsServer",
+              "sku": "2012-R2-Datacenter",
+              "version": "latest"
+            },
+            "dataDisks": {
+              "count": 1,
+              "diskSizeGB": 127,
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          }
+        },
+        
+        {
+          "type": "VirtualMachine",
+          "settings": {
+            "vmCount": 3,
+            "namePrefix": "ra-aad-ntier-biz",
+            "computerNamePrefix": "cn",
+            "size": "Standard_DS1_v2",
+            "adminUsername": "testuser",
+            "adminPassword": "<placeholder>",
+            "osType": "windows",
+            "virtualNetwork": {
+              "name": "ra-aad-ntier-vnet"
+            },
+            "nics": [
+              {
+                "subnetName": "biz",
+                "privateIPAllocationMethod": "Dynamic"
+              }
+            ],
+            "imageReference": {
+              "publisher": "MicrosoftWindowsServer",
+              "offer": "WindowsServer",
+              "sku": "2012-R2-Datacenter",
+              "version": "latest"
+            },
+            "dataDisks": {
+              "count": 1,
+              "diskSizeGB": 127,
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          }
+        },
+
+        {
+          "type": "VirtualMachine",
+          "settings": {
+            "vmCount": 3,
+            "namePrefix": "ra-aad-ntier-data",
+            "computerNamePrefix": "cn",
+            "size": "Standard_DS1_v2",
+            "adminUsername": "testuser",
+            "adminPassword": "<placeholder>",
+            "osType": "windows",
+            "virtualNetwork": {
+              "name": "ra-aad-ntier-vnet"
+            },
+            "nics": [
+              {
+                "subnetName": "data",
+                "privateIPAllocationMethod": "Dynamic"
+              }
+            ],
+            "imageReference": {
+              "publisher": "MicrosoftWindowsServer",
+              "offer": "WindowsServer",
+              "sku": "2012-R2-Datacenter",
+              "version": "latest"
+            },
+            "dataDisks": {
+              "count": 1,
+              "diskSizeGB": 127,
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          }
+        },
+       
         {
           "type": "VirtualMachineExtension",
           "settings": [
@@ -159,9 +199,53 @@
             }
           ]
         },
+
         {
           "type": "LoadBalancer",
           "settings": [
+            {
+              "name": "ra-aad-ntier-web-lb",
+              "virtualNetwork": {
+                "name": "ra-aad-ntier-vnet"
+              },
+              "frontendIPConfigurations": [
+                {
+                  "name": "ra-aad-ntier-web-lb-fe-config1",
+                  "loadBalancerType": "Public"
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "web-lbr1",
+                  "frontendPort": 80,
+                  "backendPort": 80,
+                  "protocol": "Tcp",
+                  "backendPoolName": "web-lb-bep1",
+                  "frontendIPConfigurationName": "ra-aad-ntier-web-lb-fe-config1",
+                  "enableFloatingIP": false,
+                  "probeName": "web-lbp1"
+                }
+              ],
+              "probes": [
+                {
+                  "name": "web-lbp1",
+                  "port": 80,
+                  "protocol": "Http",
+                  "requestPath": "/"
+                }
+              ],
+              "backendPools": [
+                {
+                  "name": "web-lb-bep1",
+                  "nics": [
+                    "ra-aad-ntier-web-vm1-nic1",
+                    "ra-aad-ntier-web-vm2-nic1",
+                    "ra-aad-ntier-web-vm3-nic1"
+                  ]
+                }
+              ],
+              "inboundNatRules": []
+            },
             {
               "name": "ra-aad-ntier-biz-lb",
               "virtualNetwork": {
@@ -200,55 +284,15 @@
               "backendPools": [
                 {
                   "name": "biz-lb-bep1",
-                  "nicIndex": 0
+                  "nics": [
+                    "ra-aad-ntier-biz-vm1-nic1",
+                    "ra-aad-ntier-biz-vm2-nic1",
+                    "ra-aad-ntier-biz-vm3-nic1"
+                  ]
                 }
               ],
               "inboundNatRules": []
-            }
-          ]
-        },
-        {
-          "type": "VirtualMachine",
-          "settings": {
-            "vmCount": 3,
-            "namePrefix": "ra-aad-ntier-biz",
-            "computerNamePrefix": "cn",
-            "size": "Standard_DS1_v2",
-            "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
-            "osType": "windows",
-            "virtualNetwork": {
-              "name": "ra-aad-ntier-vnet"
             },
-            "nics": [
-              {
-                "subnetName": "biz",
-                "privateIPAllocationMethod": "Dynamic",
-                "backendPoolNames": [
-                  {
-                    "name": "biz-lb-bep1",
-                    "loadBalancerName": "ra-aad-ntier-biz-lb"
-                  }
-                ]
-              }
-            ],
-            "imageReference": {
-              "publisher": "MicrosoftWindowsServer",
-              "offer": "WindowsServer",
-              "sku": "2012-R2-Datacenter",
-              "version": "latest"
-            },
-            "dataDisks": {
-              "count": 1,
-              "diskSizeGB": 127,
-              "caching": "None",
-              "createOption": "Empty"
-            }
-          }
-        },
-        {
-          "type": "LoadBalancer",
-          "settings": [
             {
               "name": "ra-aad-ntier-data-lb",
               "virtualNetwork": {
@@ -287,90 +331,96 @@
               "backendPools": [
                 {
                   "name": "data-lb-bep1",
-                  "nicIndex": 0
+                  "nics": [
+                    "ra-aad-ntier-data-vm1-nic1",
+                    "ra-aad-ntier-data-vm2-nic1",
+                    "ra-aad-ntier-data-vm3-nic1"
+                  ]
                 }
               ],
               "inboundNatRules": []
             }
           ]
         },
-        {
-          "type": "VirtualMachine",
-          "settings": {
-            "vmCount": 3,
-            "namePrefix": "ra-aad-ntier-data",
-            "computerNamePrefix": "cn",
-            "size": "Standard_DS1_v2",
-            "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
-            "osType": "windows",
-            "virtualNetwork": {
-              "name": "ra-aad-ntier-vnet"
-            },
-            "nics": [
-              {
-                "subnetName": "data",
-                "privateIPAllocationMethod": "Dynamic",
-                "backendPoolNames": [
-                  {
-                    "name": "data-lb-bep1",
-                    "loadBalancerName": "ra-aad-ntier-data-lb"
-                  }
-                ]
-              }
-            ],
-            "imageReference": {
-              "publisher": "MicrosoftWindowsServer",
-              "offer": "WindowsServer",
-              "sku": "2012-R2-Datacenter",
-              "version": "latest"
-            },
-            "dataDisks": {
-              "count": 1,
-              "diskSizeGB": 127,
-              "caching": "None",
-              "createOption": "Empty"
-            }
-          }
-        },
-        {
-          "type": "VirtualMachine",
-          "settings": {
-            "vmCount": 1,
-            "namePrefix": "ra-aad-ntier-mgmt",
-            "computerNamePrefix": "cn",
-            "size": "Standard_DS1_v2",
-            "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
-            "osType": "windows",
-            "virtualNetwork": {
-              "name": "ra-aad-ntier-vnet"
-            },
-            "nics": [
-              {
-                "isPublic": true,
-                "publicIPAllocationMethod": "Static",
-                "subnetName": "mgmt",
-                "privateIPAllocationMethod": "Dynamic"
-              }
-            ],
-            "imageReference": {
-              "publisher": "MicrosoftWindowsServer",
-              "offer": "WindowsServer",
-              "sku": "2012-R2-Datacenter",
-              "version": "latest"
-            },
-            "dataDisks": {
-              "count": 1,
-              "diskSizeGB": 127,
-              "caching": "None",
-              "createOption": "Empty"
-            }
-          }
-        },
+
         {
           "type": "NetworkSecurityGroup",
           "settings": [
+            {
+              "name": "ra-aad-ntier-mgmt-nsg",
+              "virtualNetworks": [
+                {
+                  "name": "ra-aad-ntier-vnet",
+                  "subnets": [
+                    "mgmt"
+                  ]
+                }
+              ],
+              "securityRules": [
+                {
+                  "name": "default-allow-rdp",
+                  "description": "Allow RDP Subnet",
+                  "protocol": "TCP",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 3389,
+                  "sourceAddressPrefix": "*",
+                  "destinationAddressPrefix": "*",
+                  "access": "Allow",
+                  "priority": 100,
+                  "direction": "Inbound"
+                }
+              ]
+            },
+
+            {
+              "name": "ra-aad-ntier-web-nsg",
+              "virtualNetworks": [
+                {
+                  "name": "ra-aad-ntier-vnet",
+                  "subnets": [
+                    "web"
+                  ]
+                }
+              ],
+              "securityRules": [
+                {
+                  "name": "allow-http-traffic-from-external",
+                  "description": "Allow http traffic originating externally.",
+                  "protocol": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 80,
+                  "sourceAddressPrefix": "*",
+                  "destinationAddressPrefix": "*",
+                  "access": "Allow",
+                  "priority": 100,
+                  "direction": "Inbound"
+                },
+                {
+                  "name": "allow-http-traffic-from-vnet",
+                  "description": "Allow http traffic originating from vnet.",
+                  "protocol": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 80,
+                  "sourceAddressPrefix": "10.0.0.0/16",
+                  "destinationAddressPrefix": "*",
+                  "access": "Allow",
+                  "priority": 200,
+                  "direction": "Inbound"
+                },
+                {
+                  "name": "allow-mgmt-rdp",
+                  "direction": "Inbound",
+                  "priority": 300,
+                  "sourceAddressPrefix": "10.0.0.128/25",
+                  "destinationAddressPrefix": "*",
+                  "sourcePortRange": "*",
+                  "destinationPortRange": 3389,
+                  "access": "Allow",
+                  "protocol": "TCP"
+                }
+              ]
+            },
+            
             {
               "name": "ra-aad-ntier-biz-nsg",
               "virtualNetworks": [
@@ -397,28 +447,17 @@
                 {
                   "name": "allow-mgmt-rdp",
                   "direction": "Inbound",
-                  "priority": 110,
+                  "priority": 200,
                   "sourceAddressPrefix": "10.0.0.128/25",
                   "destinationAddressPrefix": "*",
                   "sourcePortRange": "*",
                   "destinationPortRange": 3389,
                   "access": "Allow",
                   "protocol": "TCP"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 120,
-                  "direction": "Inbound"
                 }
               ]
             },
+
             {
               "name": "ra-aad-ntier-data-nsg",
               "virtualNetworks": [
@@ -445,146 +484,13 @@
                 {
                   "name": "allow-mgmt-rdp",
                   "direction": "Inbound",
-                  "priority": 110,
+                  "priority": 200,
                   "sourceAddressPrefix": "10.0.0.128/25",
                   "destinationAddressPrefix": "*",
                   "sourcePortRange": "*",
                   "destinationPortRange": 3389,
                   "access": "Allow",
                   "protocol": "TCP"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 120,
-                  "direction": "Inbound"
-                }
-              ]
-            },
-            {
-              "name": "ra-aad-ntier-web-nsg",
-              "virtualNetworks": [
-                {
-                  "name": "ra-aad-ntier-vnet",
-                  "subnets": [
-                    "web"
-                  ]
-                }
-              ],
-              "securityRules": [
-                {
-                  "name": "allow-http-traffic-from-external",
-                  "description": "Allow http traffic originating externally.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 80,
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 100,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-https-traffic-from-external",
-                  "description": "Allow https traffic originating externally.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 443,
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 110,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-http-traffic-from-vnet",
-                  "description": "Allow http traffic originating from vnet.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 80,
-                  "sourceAddressPrefix": "10.0.0.0/16",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 120,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-https-traffic-from-vnet",
-                  "description": "Allow https traffic originating from vnet.",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 443,
-                  "sourceAddressPrefix": "10.0.0.0/16",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 130,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "allow-mgmt-rdp",
-                  "direction": "Inbound",
-                  "priority": 140,
-                  "sourceAddressPrefix": "10.0.0.128/25",
-                  "destinationAddressPrefix": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 3389,
-                  "access": "Allow",
-                  "protocol": "TCP"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 150,
-                  "direction": "Inbound"
-                }
-              ]
-            },
-            {
-              "name": "ra-aad-ntier-mgmt-nsg",
-              "virtualNetworks": [
-                {
-                  "name": "ra-aad-ntier-vnet",
-                  "subnets": [
-                    "mgmt"
-                  ]
-                }
-              ],
-              "securityRules": [
-                {
-                  "name": "default-allow-rdp",
-                  "description": "Allow RDP Subnet",
-                  "protocol": "TCP",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": 3389,
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Allow",
-                  "priority": 100,
-                  "direction": "Inbound"
-                },
-                {
-                  "name": "deny-other-traffic",
-                  "description": "Deny all other traffic",
-                  "protocol": "*",
-                  "sourcePortRange": "*",
-                  "destinationPortRange": "*",
-                  "sourceAddressPrefix": "*",
-                  "destinationAddressPrefix": "*",
-                  "access": "Deny",
-                  "priority": 110,
-                  "direction": "Inbound"
                 }
               ]
             }

--- a/azure-ad/onprem.json
+++ b/azure-ad/onprem.json
@@ -31,28 +31,6 @@
           ]
         },
         {
-          "type": "NetworkSecurityGroup",
-          "settings": [
-            {
-              "name": "ra-aad-onpremise-nsg",
-              "securityRules": [
-                {
-                  "name": "RDP"
-                }
-              ],
-              "virtualNetworks": [
-                {
-                  "name": "ra-aad-onpremise-vnet",
-                  "subnets": [
-                    "adds",
-                    "adc"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "VirtualMachine",
           "settings": {
             "vmCount": 3,
@@ -61,7 +39,7 @@
             "size": "Standard_DS3_v2",
             "osType": "windows",
             "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
+            "adminPassword": "<placeholder>",
             "virtualNetwork": {
               "name": "ra-aad-onpremise-vnet"
             },
@@ -97,7 +75,7 @@
             "size": "Standard_DS3_v2",
             "osType": "windows",
             "adminUsername": "testuser",
-            "adminPassword": "AweS0me@PW",
+            "adminPassword": "<placeholder>",
             "virtualNetwork": {
               "name": "ra-aad-onpremise-vnet"
             },
@@ -156,8 +134,8 @@
                   },
                   "protectedSettings": {
                     "Items": {
-                      "AdminPassword": "AweS0me@PW",
-                      "SafeModeAdminPassword": "Saf3M0de@PW"
+                      "AdminPassword": "<placeholder>",
+                      "SafeModeAdminPassword": "<placeholder>"
                     }
                   }
                 }
@@ -180,7 +158,7 @@
                   "typeHandlerVersion": "2.7",
                   "autoUpgradeMinorVersion": true,
                   "settings": {
-                    "ModulesUrl": "https://github.com/mspnp/identity-reference-architectures/raw/azure-ad/extensions/azure-ad.zip",
+                    "ModulesUrl": "https://github.com/mspnp/identity-reference-architectures/raw/master/azure-ad/extensions/azure-ad.zip",
                     "ConfigurationFunction": "add-controller.ps1\\AddController",
                     "Properties": {
                       "DomainName": "contoso.com",
@@ -198,8 +176,8 @@
                   },
                   "protectedSettings": {
                     "Items": {
-                      "AdminPassword": "AweS0me@PW",
-                      "SafeModeAdminPassword": "Saf3M0de@PW"
+                      "AdminPassword": "<placeholder>",
+                      "SafeModeAdminPassword": "<placeholder>"
                     }
                   }
                 }
@@ -235,7 +213,7 @@
                   },
                   "protectedSettings": {
                     "Items": {
-                      "Password": "AweS0me@PW"
+                      "Password": "<placeholder>"
                     }
                   }
                 }
@@ -268,6 +246,28 @@
               "dnsServers": [
                 "192.168.0.4",
                 "192.168.0.5"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "NetworkSecurityGroup",
+          "settings": [
+            {
+              "name": "ra-aad-onpremise-nsg",
+              "securityRules": [
+                {
+                  "name": "RDP"
+                }
+              ],
+              "virtualNetworks": [
+                {
+                  "name": "ra-aad-onpremise-vnet",
+                  "subnets": [
+                    "adds",
+                    "adc"
+                  ]
+                }
               ]
             }
           ]


### PR DESCRIPTION
- First creates VMs and then the load balancer using the NIC names to link them, instead of using backendPoolNames.
- Fix a broken url to download azure-ad extension
- Json content reordering to make it easier to understand and follow
- NSG rules improvements: some unneccessary rules were removed as they are already present as defaults
